### PR TITLE
disabled created list for now

### DIFF
--- a/public/js/dolphin/plots.js
+++ b/public/js/dolphin/plots.js
@@ -17,6 +17,7 @@ function populateFileList(){
                 }
               }
 		});
+  /*
   $.ajax({ type: "GET",
 			url: BASE_PATH + "/public/ajax/ngsquerydb.php",
             data: { p: "getCustomTSV" },
@@ -31,6 +32,7 @@ function populateFileList(){
                 }
               }
 		});
+  */
 	$('.panel').overflow = scroll;
 }
 


### PR DESCRIPTION
For now this will disabled the 'Created || <custom_table_name>' from the dropdown of plots page.  custom plots can still be mapped from the table containing the list of saved custom tables.