### PR TITLE
2016 02 04 cleaning

### DIFF
--- a/public/ajax/kill_pid.php
+++ b/public/ajax/kill_pid.php
@@ -20,7 +20,6 @@ if($p == 'killRun')
 	if($pids[0]->runworkflow_pid != NULL){
 		$workflow_pid = $pids[0]->runworkflow_pid;
 		$grep_check_workflow = "ps -ef | grep '[".substr($workflow_pid, 0, 1)."]".substr($workflow_pid,1)."'";
-		var_dump($grep_check_workflow);
 		$grep_find_workflow = pclose(popen( $grep_check_workflow, "r" ) );
 		if($grep_find_workflow > 0 && $grep_find_workflow != NULL){
 			pclose(popen( "kill -9 $workflow_pid", "r" ) );

--- a/public/js/dolphin/ngstrack_stats.js
+++ b/public/js/dolphin/ngstrack_stats.js
@@ -430,6 +430,7 @@ function exportExcel(){
 				success : function(s)
 				{
 					var ES = JSON.parse(s);
+					console.log(ES);
 					if (ES.length == 1) {
 						var file_path;
 						$.ajax({ type: "GET",


### PR DESCRIPTION
Removing the var_dump should solve the stopped/error issue.  The rest of the JSON.parse errors have been tested.