### PR TITLE
2016 10 11 tables

### DIFF
--- a/public/ajax/tablegenerator.php
+++ b/public/ajax/tablegenerator.php
@@ -167,8 +167,16 @@ else if ($p == 'createTableFile')
 else if ($p == 'convertToTSV')
 {       
 	if (isset($_GET['url'])){$url = $_GET['url'];}
-	$json_data = json_decode(file_get_contents($url));
-	
+	$json_data_string = substr(file_get_contents($url), 1, -1);
+	$json_string_array = explode($json_data_string, "},");
+	$json_data = array();
+	foreach($json_string_array as $json_string_frag){
+		if(end($json_string_array) == $json_string_frag){
+			array_push($json_data, json_decode($json_string_frag . "}"));
+		}else{
+			array_push($json_data, json_decode($json_string_frag));
+		}
+	}
 	$user = $_SESSION['user'].'_'.date('Y-m-d-H-i-s').'.tsv';
 	$file = fopen('../tmp/files/'.$user, "w");
 	$toggle = true;

--- a/public/ajax/tablegenerator.php
+++ b/public/ajax/tablegenerator.php
@@ -168,10 +168,10 @@ else if ($p == 'convertToTSV')
 {       
 	if (isset($_GET['url'])){$url = $_GET['url'];}
 	$json_data_string = substr(file_get_contents($url), 1, -1);
-	$json_string_array = explode($json_data_string, "},");
+	$json_string_array = explode("},", $json_data_string);
 	$json_data = array();
 	foreach($json_string_array as $json_string_frag){
-		if(end($json_string_array) == $json_string_frag){
+		if(end($json_string_array) != $json_string_frag){
 			array_push($json_data, json_decode($json_string_frag . "}"));
 		}else{
 			array_push($json_data, json_decode($json_string_frag));


### PR DESCRIPTION
Instead of converting the entire string, convert the components individually as to not hit the memory limit for json_decode()